### PR TITLE
[feat]: add .env.example and implement guest book APIs with OAuth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,20 @@
+# GitHub OAuth App (https://github.com/settings/developers)
+GITHUB_CLIENT_ID=
+GITHUB_CLIENT_SECRET=
+
+# Random secret for signing session cookies (min 32 chars)
+# Generate one: openssl rand -base64 32
+SESSION_SECRET=
+
+# Vercel Postgres (from Vercel dashboard → Storage → your DB → .env.local tab)
+POSTGRES_URL=
+POSTGRES_PRISMA_URL=
+POSTGRES_URL_NO_SSL=
+POSTGRES_URL_NON_POOLING=
+POSTGRES_USER=
+POSTGRES_HOST=
+POSTGRES_PASSWORD=
+POSTGRES_DATABASE=
+
+# Public site URL (no trailing slash)
+NEXT_PUBLIC_SITE_URL=http://localhost:3000

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@emotion/is-prop-valid": "^1.4.0",
         "@headlessui/react": "^2.2.10",
+        "@neondatabase/serverless": "^1.1.0",
         "@tailwindcss/postcss": "^4.3.0",
         "@tailwindcss/typography": "^0.5.19",
         "@types/node": "24.1.0",
@@ -17,7 +18,6 @@
         "@types/react-dom": "latest",
         "@vercel/analytics": "^2.0.1",
         "@vercel/og": "^0.11.1",
-        "@vercel/postgres": "^0.10.0",
         "@vercel/speed-insights": "^2.0.0",
         "arctic": "^3.7.0",
         "autoprefixer": "10.5.0",
@@ -1315,12 +1315,12 @@
       }
     },
     "node_modules/@neondatabase/serverless": {
-      "version": "0.9.5",
-      "resolved": "https://registry.npmjs.org/@neondatabase/serverless/-/serverless-0.9.5.tgz",
-      "integrity": "sha512-siFas6gItqv6wD/pZnvdu34wEqgG3nSE6zWZdq5j2DEsa+VvX8i/5HXJOo06qrw5axPXn+lGCxeR+NLaSPIXug==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@neondatabase/serverless/-/serverless-1.1.0.tgz",
+      "integrity": "sha512-r3ZZhRjEcfEdKIZnoB1RusNgvHuaBRqfCzV4Gi+5A9yUX0S4HTws/ASWqt13wL4y4I+0rqsWGdA2w7EQXHi3+Q==",
       "license": "MIT",
-      "dependencies": {
-        "@types/pg": "8.11.6"
+      "engines": {
+        "node": ">=19.0.0"
       }
     },
     "node_modules/@next/env": {
@@ -2090,17 +2090,6 @@
         "undici-types": "~7.8.0"
       }
     },
-    "node_modules/@types/pg": {
-      "version": "8.11.6",
-      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.11.6.tgz",
-      "integrity": "sha512-/2WmmBXHLsfRqzfHW7BNZ8SbYzE8OSk7i3WjFYvfgRHj7S1xj+16Je5fUKv3lVdVzk/zn9TXOqf+avFCFIE0yQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "pg-protocol": "*",
-        "pg-types": "^4.0.1"
-      }
-    },
     "node_modules/@types/react": {
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
@@ -2658,20 +2647,6 @@
         "sharp": "^0.34.5"
       }
     },
-    "node_modules/@vercel/postgres": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@vercel/postgres/-/postgres-0.10.0.tgz",
-      "integrity": "sha512-fSD23DxGND40IzSkXjcFcxr53t3Tiym59Is0jSYIFpG4/0f0KO9SGtcp1sXiebvPaGe7N/tU05cH4yt2S6/IPg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@neondatabase/serverless": "^0.9.3",
-        "bufferutil": "^4.0.8",
-        "ws": "^8.17.1"
-      },
-      "engines": {
-        "node": ">=18.14"
-      }
-    },
     "node_modules/@vercel/speed-insights": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@vercel/speed-insights/-/speed-insights-2.0.0.tgz",
@@ -3175,19 +3150,6 @@
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "license": "MIT"
-    },
-    "node_modules/bufferutil": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.8.tgz",
-      "integrity": "sha512-4T53u4PdgsXqKaIctwF8ifXlRTTmEPJ8iEPWFdGZvcf7sbwYo6FKFEX9eNNAnzFZ7EzJAQ3CJeOtCRA4rDp7Pw==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "node-gyp-build": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=6.14.2"
-      }
     },
     "node_modules/call-bind": {
       "version": "1.0.9",
@@ -7941,17 +7903,6 @@
         "semver": "bin/semver.js"
       }
     },
-    "node_modules/node-gyp-build": {
-      "version": "4.8.4",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
-      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
-      "license": "MIT",
-      "bin": {
-        "node-gyp-build": "bin.js",
-        "node-gyp-build-optional": "optional.js",
-        "node-gyp-build-test": "build-test.js"
-      }
-    },
     "node_modules/node-releases": {
       "version": "2.0.37",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.37.tgz",
@@ -8072,12 +8023,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/obuf": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
-      "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==",
-      "license": "MIT"
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -8227,48 +8172,6 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "license": "MIT"
     },
-    "node_modules/pg-int8": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
-      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/pg-numeric": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/pg-numeric/-/pg-numeric-1.0.2.tgz",
-      "integrity": "sha512-BM/Thnrw5jm2kKLE5uJkXqqExRUY/toLHda65XgFTBTFYZyopbKjBe29Ii3RbkvlsMoFwD+tHeGaCjjv0gHlyw==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/pg-protocol": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.7.0.tgz",
-      "integrity": "sha512-hTK/mE36i8fDDhgDFjy6xNOG+LCorxLG3WO17tku+ij6sVHXh1jQUJ8hYAnRhNla4QVD2H8er/FOjc/+EgC6yQ==",
-      "license": "MIT"
-    },
-    "node_modules/pg-types": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-4.0.2.tgz",
-      "integrity": "sha512-cRL3JpS3lKMGsKaWndugWQoLOCoP+Cic8oseVcbr0qhPzYD5DWXK+RZ9LY9wxRf7RQia4SCwQlXk0q6FCPrVng==",
-      "license": "MIT",
-      "dependencies": {
-        "pg-int8": "1.0.1",
-        "pg-numeric": "1.0.2",
-        "postgres-array": "~3.0.1",
-        "postgres-bytea": "~3.0.0",
-        "postgres-date": "~2.1.0",
-        "postgres-interval": "^3.0.0",
-        "postgres-range": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -8341,51 +8244,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
-      "license": "MIT"
-    },
-    "node_modules/postgres-array": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-3.0.2.tgz",
-      "integrity": "sha512-6faShkdFugNQCLwucjPcY5ARoW1SlbnrZjmGl0IrrqewpvxvhSLHimCVzqeuULCbG0fQv7Dtk1yDbG3xv7Veog==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/postgres-bytea": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-3.0.0.tgz",
-      "integrity": "sha512-CNd4jim9RFPkObHSjVHlVrxoVQXz7quwNFpz7RY1okNNme49+sVyiTvTRobiLV548Hx/hb1BG+iE7h9493WzFw==",
-      "license": "MIT",
-      "dependencies": {
-        "obuf": "~1.1.2"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/postgres-date": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-2.1.0.tgz",
-      "integrity": "sha512-K7Juri8gtgXVcDfZttFKVmhglp7epKb1K4pgrkLxehjqkrgPhfG6OO8LHLkfaqkbpjNRnra018XwAr1yQFWGcA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/postgres-interval": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-3.0.0.tgz",
-      "integrity": "sha512-BSNDnbyZCXSxgA+1f5UU2GmwhoI0aU5yMxRGO8CdFEcY2BQF9xm/7MqKnYoM1nJDk8nONNWDk9WeSmePFhQdlw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/postgres-range": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/postgres-range/-/postgres-range-1.1.4.tgz",
-      "integrity": "sha512-i/hbxIE9803Alj/6ytL7UHQxRvZkI9O4Sy+J3HGc4F4oo/2eQAjTSNJ0bfxyse3bH0nuVesCk+3IRLaMtG3H6w==",
       "license": "MIT"
     },
     "node_modules/prelude-ls": {
@@ -12567,27 +12425,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/ws": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
       }
     },
     "node_modules/y18n": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@emotion/is-prop-valid": "^1.4.0",
     "@headlessui/react": "^2.2.10",
+    "@neondatabase/serverless": "^1.1.0",
     "@tailwindcss/postcss": "^4.3.0",
     "@tailwindcss/typography": "^0.5.19",
     "@types/node": "24.1.0",
@@ -19,7 +20,6 @@
     "@types/react-dom": "latest",
     "@vercel/analytics": "^2.0.1",
     "@vercel/og": "^0.11.1",
-    "@vercel/postgres": "^0.10.0",
     "@vercel/speed-insights": "^2.0.0",
     "arctic": "^3.7.0",
     "autoprefixer": "10.5.0",

--- a/src/app/api/auth/github/callback/route.ts
+++ b/src/app/api/auth/github/callback/route.ts
@@ -1,0 +1,59 @@
+import { GitHub } from "arctic";
+import { cookies } from "next/headers";
+import { setSession } from "@/lib/session";
+import { NextRequest } from "next/server";
+
+export async function GET(req: NextRequest): Promise<Response> {
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL!;
+  const { searchParams } = new URL(req.url);
+  const code = searchParams.get("code");
+  const state = searchParams.get("state");
+
+  const cookieStore = await cookies();
+  const storedState = cookieStore.get("github_oauth_state")?.value;
+  cookieStore.delete("github_oauth_state");
+
+  if (!code || !state || state !== storedState) {
+    return Response.redirect(`${siteUrl}/guestbook?error=invalid_state`);
+  }
+
+  const github = new GitHub(
+    process.env.GITHUB_CLIENT_ID!,
+    process.env.GITHUB_CLIENT_SECRET!,
+    `${siteUrl}/api/auth/github/callback`
+  );
+
+  try {
+    const tokens = await github.validateAuthorizationCode(code);
+    const accessToken = tokens.accessToken();
+
+    const userRes = await fetch("https://api.github.com/user", {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        "User-Agent": "theniidromo-guestbook",
+      },
+    });
+
+    if (!userRes.ok) {
+      return Response.redirect(`${siteUrl}/guestbook?error=github_api`);
+    }
+
+    const user = await userRes.json() as {
+      id: number;
+      login: string;
+      name: string | null;
+      avatar_url: string;
+    };
+
+    await setSession({
+      githubId: user.id,
+      username: user.login,
+      name: user.name ?? user.login,
+      avatarUrl: user.avatar_url,
+    });
+
+    return Response.redirect(`${siteUrl}/guestbook`);
+  } catch {
+    return Response.redirect(`${siteUrl}/guestbook?error=oauth_failed`);
+  }
+}

--- a/src/app/api/auth/github/route.ts
+++ b/src/app/api/auth/github/route.ts
@@ -1,0 +1,24 @@
+import { GitHub, generateState } from "arctic";
+import { cookies } from "next/headers";
+
+export async function GET(): Promise<Response> {
+  const github = new GitHub(
+    process.env.GITHUB_CLIENT_ID!,
+    process.env.GITHUB_CLIENT_SECRET!,
+    `${process.env.NEXT_PUBLIC_SITE_URL}/api/auth/github/callback`
+  );
+
+  const state = generateState();
+  const url = github.createAuthorizationURL(state, ["read:user"]);
+
+  const cookieStore = await cookies();
+  cookieStore.set("github_oauth_state", state, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "lax",
+    maxAge: 60 * 10,
+    path: "/",
+  });
+
+  return Response.redirect(url.toString());
+}

--- a/src/app/api/auth/signout/route.ts
+++ b/src/app/api/auth/signout/route.ts
@@ -1,0 +1,6 @@
+import { clearSession } from "@/lib/session";
+
+export async function POST(): Promise<Response> {
+  await clearSession();
+  return Response.json({ ok: true });
+}

--- a/src/app/api/guestbook/route.ts
+++ b/src/app/api/guestbook/route.ts
@@ -1,0 +1,53 @@
+import { neon } from "@neondatabase/serverless";
+
+const sql = neon(process.env.DATABASE_URL!);
+import { getSession } from "@/lib/session";
+import { NextRequest } from "next/server";
+
+async function ensureTable() {
+  await sql`
+    CREATE TABLE IF NOT EXISTS guestbook (
+      id SERIAL PRIMARY KEY,
+      github_id INTEGER NOT NULL,
+      username TEXT NOT NULL,
+      name TEXT NOT NULL,
+      avatar_url TEXT NOT NULL,
+      message TEXT NOT NULL,
+      created_at TIMESTAMPTZ DEFAULT NOW()
+    )
+  `;
+}
+
+export async function GET() {
+  await ensureTable();
+  const rows = await sql`
+    SELECT id, username, name, avatar_url, message, created_at
+    FROM guestbook
+    ORDER BY created_at DESC
+    LIMIT 100
+  `;
+  return Response.json(rows);
+}
+
+export async function POST(req: NextRequest) {
+  const session = await getSession();
+  if (!session) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const body = await req.json() as { message?: string };
+  const message = body.message?.trim();
+  if (!message || message.length < 1 || message.length > 500) {
+    return Response.json({ error: "Message must be 1–500 characters" }, { status: 400 });
+  }
+
+  await ensureTable();
+
+  const rows = await sql`
+    INSERT INTO guestbook (github_id, username, name, avatar_url, message)
+    VALUES (${session.githubId}, ${session.username}, ${session.name}, ${session.avatarUrl}, ${message})
+    RETURNING id, username, name, avatar_url, message, created_at
+  `;
+
+  return Response.json(rows[0], { status: 201 });
+}

--- a/src/app/guestbook/GuestbookClient.tsx
+++ b/src/app/guestbook/GuestbookClient.tsx
@@ -1,0 +1,185 @@
+"use client";
+
+import { useState } from "react";
+import Image from "next/image";
+import Link from "next/link";
+import { SiGithub } from "react-icons/si";
+import { format } from "date-fns";
+
+interface Entry {
+  id: number;
+  username: string;
+  name: string;
+  avatar_url: string;
+  message: string;
+  created_at: string;
+}
+
+interface Session {
+  githubId: number;
+  username: string;
+  name: string;
+  avatarUrl: string;
+}
+
+interface GuestbookClientProps {
+  initialEntries: Entry[];
+  session: Session | null;
+  error?: string;
+}
+
+export function GuestbookClient({ initialEntries, session, error }: GuestbookClientProps) {
+  const [entries, setEntries] = useState<Entry[]>(initialEntries);
+  const [message, setMessage] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [formError, setFormError] = useState("");
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!message.trim()) return;
+    setSubmitting(true);
+    setFormError("");
+
+    const res = await fetch("/api/guestbook", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ message: message.trim() }),
+    });
+
+    if (res.ok) {
+      const entry = await res.json() as Entry;
+      setEntries((prev) => [entry, ...prev]);
+      setMessage("");
+    } else {
+      const body = await res.json() as { error?: string };
+      setFormError(body.error ?? "Something went wrong");
+    }
+    setSubmitting(false);
+  }
+
+  async function handleSignOut() {
+    await fetch("/api/auth/signout", { method: "POST" });
+    window.location.reload();
+  }
+
+  return (
+    <div className="flex flex-col gap-10 mb-20">
+      <div>
+        <h1 className="text-xl font-bold tracking-tight text-foreground mb-1">Guestbook</h1>
+        <p className="text-sm text-zinc-500 dark:text-zinc-400">
+          Leave a message — I read every one.
+        </p>
+      </div>
+
+      {error && (
+        <p className="text-xs text-red-500">Authentication failed. Please try again.</p>
+      )}
+
+      {/* Sign form */}
+      <div className="rounded-xl border border-zinc-200 dark:border-zinc-800 p-4">
+        {session ? (
+          <form onSubmit={handleSubmit} className="flex flex-col gap-3">
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-2">
+                <Image
+                  src={session.avatarUrl}
+                  alt={session.username}
+                  width={24}
+                  height={24}
+                  className="rounded-full"
+                />
+                <span className="text-xs text-zinc-500 dark:text-zinc-400">
+                  Signed in as{" "}
+                  <a
+                    href={`https://github.com/${session.username}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="font-medium text-foreground hover:opacity-70 transition-opacity"
+                  >
+                    @{session.username}
+                  </a>
+                </span>
+              </div>
+              <button
+                type="button"
+                onClick={handleSignOut}
+                className="text-[10px] text-zinc-400 hover:text-foreground transition-colors"
+              >
+                Sign out
+              </button>
+            </div>
+            <textarea
+              value={message}
+              onChange={(e) => setMessage(e.target.value)}
+              placeholder="Your message..."
+              maxLength={500}
+              rows={3}
+              className="w-full rounded-lg border border-zinc-200 dark:border-zinc-700 bg-transparent px-3 py-2 text-sm text-foreground placeholder:text-zinc-400 focus:outline-none focus:ring-1 focus:ring-zinc-400 dark:focus:ring-zinc-600 resize-none"
+            />
+            {formError && <p className="text-xs text-red-500">{formError}</p>}
+            <div className="flex items-center justify-between">
+              <span className="text-[10px] text-zinc-400">{message.length}/500</span>
+              <button
+                type="submit"
+                disabled={submitting || !message.trim()}
+                className="text-xs font-medium px-3 py-1.5 rounded-lg bg-foreground text-background disabled:opacity-40 hover:opacity-80 transition-opacity"
+              >
+                {submitting ? "Signing..." : "Sign"}
+              </button>
+            </div>
+          </form>
+        ) : (
+          <div className="flex flex-col items-start gap-3">
+            <p className="text-sm text-zinc-500 dark:text-zinc-400">
+              Sign in with GitHub to leave a message.
+            </p>
+            <Link
+              href="/api/auth/github"
+              className="inline-flex items-center gap-2 text-xs font-medium px-3 py-1.5 rounded-lg bg-foreground text-background hover:opacity-80 transition-opacity"
+            >
+              <SiGithub size={13} />
+              Sign in with GitHub
+            </Link>
+          </div>
+        )}
+      </div>
+
+      {/* Entries */}
+      <div className="flex flex-col gap-4">
+        {entries.length === 0 ? (
+          <p className="text-sm text-zinc-400 dark:text-zinc-500">No entries yet. Be the first!</p>
+        ) : (
+          entries.map((entry) => (
+            <div key={entry.id} className="flex gap-3">
+              <Image
+                src={entry.avatar_url}
+                alt={entry.username}
+                width={28}
+                height={28}
+                className="rounded-full shrink-0 mt-0.5"
+              />
+              <div className="flex flex-col gap-0.5 min-w-0">
+                <div className="flex items-center gap-2">
+                  <a
+                    href={`https://github.com/${entry.username}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-xs font-medium text-foreground hover:opacity-70 transition-opacity"
+                  >
+                    {entry.name}
+                  </a>
+                  <span className="text-[10px] text-zinc-400 dark:text-zinc-500 shrink-0">
+                    {format(new Date(entry.created_at), "d MMM yyyy")}
+                  </span>
+                </div>
+                <p className="text-sm text-zinc-600 dark:text-zinc-400 break-words">
+                  {entry.message}
+                </p>
+              </div>
+            </div>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/guestbook/page.tsx
+++ b/src/app/guestbook/page.tsx
@@ -1,0 +1,65 @@
+import { neon } from "@neondatabase/serverless";
+
+const sql = neon(process.env.DATABASE_URL!);
+import { getSession } from "@/lib/session";
+import { GuestbookClient } from "./GuestbookClient";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Guestbook | The Nii Dromo",
+  description: "Leave a message for Nii Dromo.",
+};
+
+interface Entry {
+  id: number;
+  username: string;
+  name: string;
+  avatar_url: string;
+  message: string;
+  created_at: string;
+}
+
+async function getEntries(): Promise<Entry[]> {
+  try {
+    await sql`
+      CREATE TABLE IF NOT EXISTS guestbook (
+        id SERIAL PRIMARY KEY,
+        github_id INTEGER NOT NULL,
+        username TEXT NOT NULL,
+        name TEXT NOT NULL,
+        avatar_url TEXT NOT NULL,
+        message TEXT NOT NULL,
+        created_at TIMESTAMPTZ DEFAULT NOW()
+      )
+    `;
+    const rows = await sql`
+      SELECT id, username, name, avatar_url, message, created_at
+      FROM guestbook
+      ORDER BY created_at DESC
+      LIMIT 100
+    `;
+    return rows as Entry[];
+  } catch {
+    return [];
+  }
+}
+
+interface PageProps {
+  searchParams: Promise<{ error?: string }>;
+}
+
+export default async function GuestbookPage({ searchParams }: PageProps) {
+  const [entries, session, params] = await Promise.all([
+    getEntries(),
+    getSession(),
+    searchParams,
+  ]);
+
+  return (
+    <GuestbookClient
+      initialEntries={entries}
+      session={session}
+      error={params.error}
+    />
+  );
+}

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -1,0 +1,65 @@
+import { cookies } from "next/headers";
+
+const SESSION_COOKIE = "gb_session";
+const MAX_AGE = 60 * 60 * 24 * 7; // 7 days
+
+export interface SessionData {
+  githubId: number;
+  username: string;
+  name: string;
+  avatarUrl: string;
+}
+
+async function sign(payload: string, secret: string): Promise<string> {
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"]
+  );
+  const sig = await crypto.subtle.sign("HMAC", key, new TextEncoder().encode(payload));
+  return Buffer.from(sig).toString("base64url");
+}
+
+async function verify(payload: string, sig: string, secret: string): Promise<boolean> {
+  const expected = await sign(payload, secret);
+  return expected === sig;
+}
+
+export async function setSession(data: SessionData): Promise<void> {
+  const secret = process.env.SESSION_SECRET!;
+  const payload = Buffer.from(JSON.stringify(data)).toString("base64url");
+  const sig = await sign(payload, secret);
+  const cookieStore = await cookies();
+  cookieStore.set(SESSION_COOKIE, `${payload}.${sig}`, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "lax",
+    maxAge: MAX_AGE,
+    path: "/",
+  });
+}
+
+export async function getSession(): Promise<SessionData | null> {
+  const secret = process.env.SESSION_SECRET;
+  if (!secret) return null;
+  const cookieStore = await cookies();
+  const raw = cookieStore.get(SESSION_COOKIE)?.value;
+  if (!raw) return null;
+  const dot = raw.lastIndexOf(".");
+  if (dot === -1) return null;
+  const payload = raw.slice(0, dot);
+  const sig = raw.slice(dot + 1);
+  if (!(await verify(payload, sig, secret))) return null;
+  try {
+    return JSON.parse(Buffer.from(payload, "base64url").toString()) as SessionData;
+  } catch {
+    return null;
+  }
+}
+
+export async function clearSession(): Promise<void> {
+  const cookieStore = await cookies();
+  cookieStore.delete(SESSION_COOKIE);
+}


### PR DESCRIPTION
This pull request introduces a full-stack guestbook feature that enables users to sign in with GitHub, leave messages, and view all guestbook entries. The implementation covers authentication, session management, database integration, and the user interface. The most important changes are grouped below.

**Authentication and Session Management:**

* Implements GitHub OAuth authentication flow with endpoints for sign-in (`/api/auth/github`), callback handling (`/api/auth/github/callback`), and sign-out (`/api/auth/signout`). Session data is stored in a signed, HTTP-only cookie. [[1]](diffhunk://#diff-9cc784fe02186c53453efb70f77fe2b9d492b110e737fc4695f5ecd10c6131c5R1-R24) [[2]](diffhunk://#diff-f3781d31e7dc810139646418ccb0bd334a08015f8646f2d215bf5d054612fa0bR1-R59) [[3]](diffhunk://#diff-37f4afaaad42e1feeb0df074a095be119ad66ad67095dba159e27e87d8f56152R1-R6) [[4]](diffhunk://#diff-21fc10c4f94655deceb24134026474bee0fde89cd94b7b8b1a288b08b30cd5d0R1-R65)
* Adds `.env.example` with required environment variables for GitHub OAuth, session secret, and database connection.

**Database and API Integration:**

* Uses Neon serverless Postgres for storing and retrieving guestbook entries, with API endpoints for listing and creating entries. The guestbook table is auto-created if it doesn't exist. [[1]](diffhunk://#diff-8c6c3bb92adbf6d090741c5430673423b687cb759e2e962167dc560c382e9664R1-R53) [[2]](diffhunk://#diff-14bc5f0180c4d84d7d5c5499fad88b50fb8e7b60ba771e887791ace28b4e154cR1-R65)
* Updates dependencies to use `@neondatabase/serverless` instead of `@vercel/postgres`.

**Frontend Guestbook Interface:**

* Adds a React client component for the guestbook page, supporting sign-in/sign-out, message submission, and displaying entries with user avatars and formatted dates.
* Integrates the guestbook page with server-side data fetching and session detection, passing initial data and error states to the client component.