### PR TITLE
[feat]: implement real-time Spotify Now Playing widget

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,3 +22,8 @@ POSTGRES_DATABASE=
 
 # Public site URL (no trailing slash)
 NEXT_PUBLIC_SITE_URL=http://localhost:3000
+
+# Spotify Integration (https://developer.spotify.com/dashboard)
+SPOTIFY_CLIENT_ID=
+SPOTIFY_CLIENT_SECRET=
+SPOTIFY_REFRESH_TOKEN=

--- a/next.config.js
+++ b/next.config.js
@@ -10,6 +10,10 @@ const nextConfig = {
         protocol: "https",
         hostname: "lh3.googleusercontent.com",
       },
+      {
+        protocol: "https",
+        hostname: "i.scdn.co",
+      },
     ],
   },
 };

--- a/src/app/api/spotify/now-playing/route.ts
+++ b/src/app/api/spotify/now-playing/route.ts
@@ -1,11 +1,11 @@
 import { NextResponse } from "next/server";
-import { getNowPlaying, getRecentlyPlayed } from "@/lib/spotify";
+import { SpotifyAuthError, getNowPlaying, getRecentlyPlayed } from "@/lib/spotify";
 import { siteConfig } from "@/lib/config";
 
 export const dynamic = "force-dynamic";
 
-function isSpotifyAuthError(error: unknown) {
-  return error instanceof Error && error.message.includes("SPOTIFY_AUTH_ERROR:");
+function getDisabledResponse() {
+  return NextResponse.json({ isPlaying: false, disabled: true });
 }
 
 export async function GET() {
@@ -23,7 +23,7 @@ export async function GET() {
     const response = await getNowPlaying();
 
     // 204 No Content means no music is currently playing, or the account is offline.
-    if (response.status === 204 || !response.ok) {
+    if (response.status === 204 || response.status >= 400) {
       return getFallbackRecentlyPlayed();
     }
 
@@ -57,10 +57,7 @@ export async function GET() {
     );
   } catch (error: any) {
     console.error("Error fetching now-playing from Spotify:", error.message);
-
-    if (isSpotifyAuthError(error)) {
-      return NextResponse.json({ isPlaying: false, disabled: true });
-    }
+    if (error instanceof SpotifyAuthError) return getDisabledResponse();
 
     return getFallbackRecentlyPlayed();
   }
@@ -72,7 +69,7 @@ async function getFallbackRecentlyPlayed() {
 
     if (!response.ok) {
       if (response.status === 401 || response.status === 403) {
-        return NextResponse.json({ isPlaying: false, disabled: true });
+        return getDisabledResponse();
       }
 
       return NextResponse.json({ isPlaying: false });
@@ -108,10 +105,7 @@ async function getFallbackRecentlyPlayed() {
     );
   } catch (error) {
     console.error("Error fetching recently-played from Spotify:", error);
-
-    if (isSpotifyAuthError(error)) {
-      return NextResponse.json({ isPlaying: false, disabled: true });
-    }
+    if (error instanceof SpotifyAuthError) return getDisabledResponse();
 
     return NextResponse.json({ isPlaying: false });
   }

--- a/src/app/api/spotify/now-playing/route.ts
+++ b/src/app/api/spotify/now-playing/route.ts
@@ -1,0 +1,100 @@
+import { NextResponse } from "next/server";
+import { getNowPlaying, getRecentlyPlayed } from "@/lib/spotify";
+import { siteConfig } from "@/lib/config";
+
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  // If credentials are not configured, fail gracefully and disable the feature
+  if (
+    !siteConfig.spotify.clientId ||
+    !siteConfig.spotify.clientSecret ||
+    !siteConfig.spotify.refreshToken
+  ) {
+    return NextResponse.json({ isPlaying: false, disabled: true });
+  }
+
+  try {
+    // 1. Try to get what's playing right now
+    const response = await getNowPlaying();
+
+    // 204 No Content means no music is currently playing, or the account is offline.
+    if (response.status === 204 || response.status > 400) {
+      return getFallbackRecentlyPlayed();
+    }
+
+    const song = await response.json();
+
+    if (!song || !song.item) {
+      return getFallbackRecentlyPlayed();
+    }
+
+    const isPlaying = song.is_playing;
+    const title = song.item.name;
+    const artist = song.item.artists.map((_artist: any) => _artist.name).join(", ");
+    const album = song.item.album.name;
+    const albumImageUrl = song.item.album.images[0]?.url || "";
+    const songUrl = song.item.external_urls.spotify;
+
+    return NextResponse.json(
+      {
+        isPlaying,
+        title,
+        artist,
+        album,
+        albumImageUrl,
+        songUrl,
+      },
+      {
+        headers: {
+          "Cache-Control": "no-cache, no-store, must-revalidate",
+        },
+      }
+    );
+  } catch (error: any) {
+    console.error("Error fetching now-playing from Spotify:", error.message);
+    return getFallbackRecentlyPlayed();
+  }
+}
+
+async function getFallbackRecentlyPlayed() {
+  try {
+    const response = await getRecentlyPlayed();
+
+    if (!response.ok) {
+      return NextResponse.json({ isPlaying: false });
+    }
+
+    const data = await response.json();
+    const trackData = data.items?.[0]?.track;
+
+    if (!trackData) {
+      return NextResponse.json({ isPlaying: false });
+    }
+
+    const title = trackData.name;
+    const artist = trackData.artists.map((_artist: any) => _artist.name).join(", ");
+    const album = trackData.album.name;
+    const albumImageUrl = trackData.album.images[0]?.url || "";
+    const songUrl = trackData.external_urls.spotify;
+
+    return NextResponse.json(
+      {
+        isPlaying: false,
+        title,
+        artist,
+        album,
+        albumImageUrl,
+        songUrl,
+      },
+      {
+        headers: {
+          "Cache-Control": "no-cache, no-store, must-revalidate",
+        },
+      }
+    );
+  } catch (error) {
+    console.error("Error fetching recently-played from Spotify:", error);
+    return NextResponse.json({ isPlaying: false });
+  }
+}

--- a/src/app/api/spotify/now-playing/route.ts
+++ b/src/app/api/spotify/now-playing/route.ts
@@ -4,6 +4,10 @@ import { siteConfig } from "@/lib/config";
 
 export const dynamic = "force-dynamic";
 
+function isSpotifyAuthError(error: unknown) {
+  return error instanceof Error && error.message.includes("SPOTIFY_AUTH_ERROR:");
+}
+
 export async function GET() {
   // If credentials are not configured, fail gracefully and disable the feature
   if (
@@ -19,7 +23,7 @@ export async function GET() {
     const response = await getNowPlaying();
 
     // 204 No Content means no music is currently playing, or the account is offline.
-    if (response.status === 204 || response.status > 400) {
+    if (response.status === 204 || !response.ok) {
       return getFallbackRecentlyPlayed();
     }
 
@@ -53,6 +57,11 @@ export async function GET() {
     );
   } catch (error: any) {
     console.error("Error fetching now-playing from Spotify:", error.message);
+
+    if (isSpotifyAuthError(error)) {
+      return NextResponse.json({ isPlaying: false, disabled: true });
+    }
+
     return getFallbackRecentlyPlayed();
   }
 }
@@ -62,6 +71,10 @@ async function getFallbackRecentlyPlayed() {
     const response = await getRecentlyPlayed();
 
     if (!response.ok) {
+      if (response.status === 401 || response.status === 403) {
+        return NextResponse.json({ isPlaying: false, disabled: true });
+      }
+
       return NextResponse.json({ isPlaying: false });
     }
 
@@ -95,6 +108,11 @@ async function getFallbackRecentlyPlayed() {
     );
   } catch (error) {
     console.error("Error fetching recently-played from Spotify:", error);
+
+    if (isSpotifyAuthError(error)) {
+      return NextResponse.json({ isPlaying: false, disabled: true });
+    }
+
     return NextResponse.json({ isPlaying: false });
   }
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import { allPosts } from "@/lib/content";
 import Link from "next/link";
 import { format } from "date-fns";
-import { Posts, MotionDiv, MotionHeader, SpotifyCard } from "@/components";
+import { Posts, MotionDiv, MotionHeader, SpotifyCard, NowPlaying } from "@/components";
 import { Icons } from "@/assets";
 import Image from "next/image";
 import { FiYoutube } from "react-icons/fi";
@@ -153,6 +153,7 @@ const Home = () => {
         <h2 className="text-xs font-semibold uppercase tracking-widest text-zinc-400 dark:text-zinc-500">
           Currently on repeat
         </h2>
+        <NowPlaying />
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
           {spotifyTracks.map((track) => (
             <SpotifyCard

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -4,7 +4,7 @@ import Posts from "./Posts";
 import ThemeProvider from "./ThemeProvider";
 import SchemeToggle from "./SchemeToggle";
 import { QueryProvider } from "./QueryProvider";
-import { MotionHeader, MotionDiv, MotionFooter, SpotifyCard, SignaturePad } from "./ui";
+import { MotionHeader, MotionDiv, MotionFooter, SpotifyCard, SignaturePad, NowPlaying } from "./ui";
 
 export {
   Header,
@@ -18,4 +18,5 @@ export {
   MotionFooter,
   SpotifyCard,
   SignaturePad,
+  NowPlaying,
 };

--- a/src/components/ui/NowPlaying.tsx
+++ b/src/components/ui/NowPlaying.tsx
@@ -1,0 +1,125 @@
+"use client";
+import React from "react";
+import { useSpotifyNowPlaying } from "@/hooks/useSpotify";
+import { SiSpotify } from "react-icons/si";
+import Image from "next/image";
+import { motion } from "framer-motion";
+
+const EqualizerBar = ({ delay }: { delay: number }) => (
+  <motion.span
+    className="w-[3px] bg-[#1DB954] rounded-full"
+    animate={{
+      height: ["8px", "16px", "8px", "12px", "6px", "16px"],
+    }}
+    transition={{
+      duration: 1.5,
+      repeat: Infinity,
+      ease: "easeInOut",
+      delay: delay,
+    }}
+    style={{ originY: 1 }}
+  />
+);
+
+const Equalizer = () => (
+  <div className="flex items-end gap-[2px] h-4 w-6 shrink-0">
+    <EqualizerBar delay={0} />
+    <EqualizerBar delay={0.3} />
+    <EqualizerBar delay={0.15} />
+    <EqualizerBar delay={0.45} />
+  </div>
+);
+
+export const NowPlaying = () => {
+  const { data, isLoading, isError } = useSpotifyNowPlaying();
+
+  if (isLoading) {
+    return (
+      <div className="w-full p-3 rounded-xl border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-[#121212] animate-pulse flex items-center gap-3 min-h-[64px]">
+        <div className="w-10 h-10 bg-zinc-200 dark:bg-zinc-800 rounded-lg shrink-0" />
+        <div className="flex-1 flex flex-col gap-1.5">
+          <div className="h-2.5 bg-zinc-200 dark:bg-zinc-800 rounded w-1/3" />
+          <div className="h-3 bg-zinc-200 dark:bg-zinc-800 rounded w-2/3" />
+        </div>
+      </div>
+    );
+  }
+
+  if (isError || !data || data.disabled) {
+    return null; // Hide widget entirely if variables are missing or call failed
+  }
+
+  const { isPlaying, title, artist, albumImageUrl, songUrl } = data;
+
+  const hasData = !!title;
+
+  return (
+    <a
+      href={songUrl || "https://open.spotify.com"}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="group flex items-center gap-3.5 p-3.5 rounded-xl border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-[#121212] hover:bg-zinc-50 dark:hover:bg-[#1a1a1a] hover:border-zinc-300 dark:hover:border-zinc-700 transition-all"
+    >
+      {/* Album Art */}
+      <div className="relative w-12 h-12 shrink-0 overflow-hidden rounded-lg bg-zinc-100 dark:bg-zinc-900 border border-zinc-100 dark:border-zinc-800">
+        {albumImageUrl ? (
+          <Image
+            src={albumImageUrl}
+            alt={title || "Album art"}
+            fill
+            sizes="48px"
+            className="object-cover transition-transform duration-500 group-hover:scale-105"
+          />
+        ) : (
+          <div className="flex items-center justify-center w-full h-full text-zinc-400 dark:text-zinc-600">
+            <SiSpotify size={22} />
+          </div>
+        )}
+      </div>
+
+      {/* Details */}
+      <div className="flex-1 min-w-0 flex flex-col justify-center py-0.5">
+        <div className="flex items-center gap-1.5 text-[10px] font-bold uppercase tracking-wider text-zinc-400 dark:text-zinc-500">
+          {isPlaying ? (
+            <span className="text-[#1DB954] flex items-center gap-1">
+              <span className="relative flex h-1.5 w-1.5">
+                <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-emerald-400 opacity-75"></span>
+                <span className="relative inline-flex rounded-full h-1.5 w-1.5 bg-[#1DB954]"></span>
+              </span>
+              Now Playing
+            </span>
+          ) : (
+            <span>Recently Played</span>
+          )}
+        </div>
+
+        {hasData ? (
+          <div className="mt-0.5 flex flex-col">
+            <span className="font-semibold text-sm text-zinc-800 dark:text-zinc-200 truncate leading-snug group-hover:text-foreground transition-colors">
+              {title}
+            </span>
+            <span className="text-xs text-zinc-500 dark:text-zinc-400 truncate leading-relaxed">
+              {artist}
+            </span>
+          </div>
+        ) : (
+          <span className="mt-0.5 font-medium text-xs text-zinc-500">
+            Not listening to anything
+          </span>
+        )}
+      </div>
+
+      {/* Status Indicator */}
+      <div className="shrink-0 flex items-center">
+        {isPlaying ? (
+          <Equalizer />
+        ) : (
+          <SiSpotify
+            className="text-zinc-300 dark:text-zinc-700 group-hover:text-[#1DB954] transition-colors duration-300"
+            size={18}
+          />
+        )}
+      </div>
+    </a>
+  );
+};

--- a/src/components/ui/index.tsx
+++ b/src/components/ui/index.tsx
@@ -2,5 +2,6 @@ import { MotionHeader, MotionFooter, MotionDiv } from "./Motion";
 import { Spoiler } from "./Spoiler";
 import { SpotifyCard } from "./SpotifyCard";
 import { SignaturePad } from "./SignaturePad";
+import { NowPlaying } from "./NowPlaying";
 
-export { MotionHeader, MotionFooter, MotionDiv, Spoiler, SpotifyCard, SignaturePad };
+export { MotionHeader, MotionFooter, MotionDiv, Spoiler, SpotifyCard, SignaturePad, NowPlaying };

--- a/src/hooks/useSpotify.ts
+++ b/src/hooks/useSpotify.ts
@@ -1,0 +1,24 @@
+import { useQuery } from "@tanstack/react-query";
+import axios from "axios";
+
+export interface SpotifyNowPlaying {
+  isPlaying: boolean;
+  title?: string;
+  artist?: string;
+  album?: string;
+  albumImageUrl?: string;
+  songUrl?: string;
+  disabled?: boolean;
+}
+
+export function useSpotifyNowPlaying() {
+  return useQuery<SpotifyNowPlaying>({
+    queryKey: ["spotify-now-playing"],
+    queryFn: async () => {
+      const { data } = await axios.get<SpotifyNowPlaying>("/api/spotify/now-playing");
+      return data;
+    },
+    refetchInterval: (query) => (query.state.data?.disabled ? false : 5000),
+    refetchOnWindowFocus: (query) => !query.state.data?.disabled,
+  });
+}

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -17,5 +17,10 @@ export const siteConfig = {
   admin: {
     username: process.env.NEXT_PUBLIC_ADMIN_USERNAME || process.env.ADMIN_GITHUB_USERNAME || "theniitettey",
   },
+  spotify: {
+    clientId: process.env.SPOTIFY_CLIENT_ID || "",
+    clientSecret: process.env.SPOTIFY_CLIENT_SECRET || "",
+    refreshToken: process.env.SPOTIFY_REFRESH_TOKEN || "",
+  },
   isProduction: process.env.NODE_ENV === "production",
 };

--- a/src/lib/spotify.ts
+++ b/src/lib/spotify.ts
@@ -1,0 +1,57 @@
+import { siteConfig } from "@/lib/config";
+
+const client_id = siteConfig.spotify.clientId;
+const client_secret = siteConfig.spotify.clientSecret;
+const refresh_token = siteConfig.spotify.refreshToken;
+
+const basic = Buffer.from(`${client_id}:${client_secret}`).toString("base64");
+const NOW_PLAYING_ENDPOINT = `https://api.spotify.com/v1/me/player/currently-playing`;
+const RECENTLY_PLAYED_ENDPOINT = `https://api.spotify.com/v1/me/player/recently-played?limit=1`;
+const TOKEN_ENDPOINT = `https://accounts.spotify.com/api/token`;
+
+const getAccessToken = async () => {
+  if (!client_id || !client_secret || !refresh_token) {
+    throw new Error("Spotify environment variables are missing!");
+  }
+
+  const response = await fetch(TOKEN_ENDPOINT, {
+    method: "POST",
+    headers: {
+      Authorization: `Basic ${basic}`,
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+    body: new URLSearchParams({
+      grant_type: "refresh_token",
+      refresh_token,
+    }),
+    next: { revalidate: 0 }, // Next.js 13+ App Router caching directive
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to refresh token: ${response.statusText}`);
+  }
+
+  return response.json();
+};
+
+export const getNowPlaying = async () => {
+  const { access_token } = await getAccessToken();
+
+  return fetch(NOW_PLAYING_ENDPOINT, {
+    headers: {
+      Authorization: `Bearer ${access_token}`,
+    },
+    next: { revalidate: 0 },
+  });
+};
+
+export const getRecentlyPlayed = async () => {
+  const { access_token } = await getAccessToken();
+
+  return fetch(RECENTLY_PLAYED_ENDPOINT, {
+    headers: {
+      Authorization: `Bearer ${access_token}`,
+    },
+    next: { revalidate: 0 },
+  });
+};

--- a/src/lib/spotify.ts
+++ b/src/lib/spotify.ts
@@ -9,6 +9,13 @@ const NOW_PLAYING_ENDPOINT = `https://api.spotify.com/v1/me/player/currently-pla
 const RECENTLY_PLAYED_ENDPOINT = `https://api.spotify.com/v1/me/player/recently-played?limit=1`;
 const TOKEN_ENDPOINT = `https://accounts.spotify.com/api/token`;
 
+export class SpotifyAuthError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "SpotifyAuthError";
+  }
+}
+
 const getAccessToken = async () => {
   if (!clientId || !clientSecret || !refreshToken) {
     throw new Error("Spotify environment variables are missing!");
@@ -28,7 +35,9 @@ const getAccessToken = async () => {
   });
 
   if (!response.ok) {
-    throw new Error(`SPOTIFY_AUTH_ERROR:${response.status}:${response.statusText}`);
+    throw new SpotifyAuthError(
+      `Failed to refresh token (${response.status}): ${response.statusText}`
+    );
   }
 
   return response.json();

--- a/src/lib/spotify.ts
+++ b/src/lib/spotify.ts
@@ -1,16 +1,16 @@
 import { siteConfig } from "@/lib/config";
 
-const client_id = siteConfig.spotify.clientId;
-const client_secret = siteConfig.spotify.clientSecret;
-const refresh_token = siteConfig.spotify.refreshToken;
+const clientId = siteConfig.spotify.clientId;
+const clientSecret = siteConfig.spotify.clientSecret;
+const refreshToken = siteConfig.spotify.refreshToken;
 
-const basic = Buffer.from(`${client_id}:${client_secret}`).toString("base64");
+const basic = Buffer.from(`${clientId}:${clientSecret}`).toString("base64");
 const NOW_PLAYING_ENDPOINT = `https://api.spotify.com/v1/me/player/currently-playing`;
 const RECENTLY_PLAYED_ENDPOINT = `https://api.spotify.com/v1/me/player/recently-played?limit=1`;
 const TOKEN_ENDPOINT = `https://accounts.spotify.com/api/token`;
 
 const getAccessToken = async () => {
-  if (!client_id || !client_secret || !refresh_token) {
+  if (!clientId || !clientSecret || !refreshToken) {
     throw new Error("Spotify environment variables are missing!");
   }
 
@@ -22,35 +22,35 @@ const getAccessToken = async () => {
     },
     body: new URLSearchParams({
       grant_type: "refresh_token",
-      refresh_token,
+      refresh_token: refreshToken,
     }),
     next: { revalidate: 0 }, // Next.js 13+ App Router caching directive
   });
 
   if (!response.ok) {
-    throw new Error(`Failed to refresh token: ${response.statusText}`);
+    throw new Error(`SPOTIFY_AUTH_ERROR:${response.status}:${response.statusText}`);
   }
 
   return response.json();
 };
 
 export const getNowPlaying = async () => {
-  const { access_token } = await getAccessToken();
+  const { access_token: accessToken } = await getAccessToken();
 
   return fetch(NOW_PLAYING_ENDPOINT, {
     headers: {
-      Authorization: `Bearer ${access_token}`,
+      Authorization: `Bearer ${accessToken}`,
     },
     next: { revalidate: 0 },
   });
 };
 
 export const getRecentlyPlayed = async () => {
-  const { access_token } = await getAccessToken();
+  const { access_token: accessToken } = await getAccessToken();
 
   return fetch(RECENTLY_PLAYED_ENDPOINT, {
     headers: {
-      Authorization: `Bearer ${access_token}`,
+      Authorization: `Bearer ${accessToken}`,
     },
     next: { revalidate: 0 },
   });


### PR DESCRIPTION
This pull request adds a new Spotify "Now Playing" integration to the project, allowing the site to display the user's currently playing or most recently played track from Spotify. The integration includes backend API logic, frontend components, and configuration updates. The most important changes are grouped below.

**Spotify Integration:**

* Added Spotify credentials (`SPOTIFY_CLIENT_ID`, `SPOTIFY_CLIENT_SECRET`, `SPOTIFY_REFRESH_TOKEN`) to `.env.example` and loaded them into the app via `siteConfig` for secure access to the Spotify API. [[1]](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cR25-R29) [[2]](diffhunk://#diff-0b4f5977a52cef50ed20e7cdf9761795df9ee1cb3b5e5ea45edeb9394e8a47ffR20-R24)
* Implemented `src/lib/spotify.ts` with functions to fetch the current or recently played track from Spotify using OAuth2 token refresh.
* Created a new API route at `/api/spotify/now-playing` (`src/app/api/spotify/now-playing/route.ts`) that returns the user's now playing or most recently played track, handling missing credentials and errors gracefully.

**Frontend Integration:**

* Added a new `NowPlaying` component (`src/components/ui/NowPlaying.tsx`) that displays the current or recently played track with animated visuals, and included it on the homepage below the "Currently on repeat" heading. [[1]](diffhunk://#diff-c93da30c4670673a3f8a2687fbc9b40a2b44bdbe33f53708f335748aeade1119R1-R125) [[2]](diffhunk://#diff-73d7a23e5015801b9bcc9db601d6ec9594d3eb34e5bb23154e0ae4b0c30f1a3bR156)
* Exposed the `NowPlaying` component via the main components index for easy import, and updated all relevant imports. [[1]](diffhunk://#diff-7fd43b0b162a214d655a8176a345b983bfa23ff95be8e4059e587cf9db3fc51fL7-R7) [[2]](diffhunk://#diff-7fd43b0b162a214d655a8176a345b983bfa23ff95be8e4059e587cf9db3fc51fR21) [[3]](diffhunk://#diff-5aa32f476c077195be27752e5a6b53b6f29112b36dea1607d4ed886486bd4e3bR5-R7) [[4]](diffhunk://#diff-73d7a23e5015801b9bcc9db601d6ec9594d3eb34e5bb23154e0ae4b0c30f1a3bL6-R6)

**Data Fetching:**

* Added a new React hook `useSpotifyNowPlaying` (`src/hooks/useSpotify.ts`) to fetch and cache the now playing data from the API, with automatic polling and error handling.

These changes collectively enable live Spotify playback status on the site, with robust error handling and a polished UI.