### PR TITLE
[update]: add provider field to session and update related data structures

### DIFF
--- a/src/app/api/auth/github/callback/route.ts
+++ b/src/app/api/auth/github/callback/route.ts
@@ -75,10 +75,11 @@ export async function GET(req: NextRequest): Promise<Response> {
     });
 
     await setSession({
-      githubId: canonicalId,
+      userId: canonicalId,
       username: user.login,
       name: user.name ?? user.login,
       avatarUrl: user.avatar_url,
+      provider: "github",
     });
 
     return Response.redirect(`${siteUrl}/guestbook`);

--- a/src/app/api/auth/google/callback/route.ts
+++ b/src/app/api/auth/google/callback/route.ts
@@ -69,10 +69,11 @@ export async function GET(req: NextRequest): Promise<Response> {
     });
 
     await setSession({
-      githubId: canonicalId,
+      userId: canonicalId,
       username: derivedUsername,
       name: user.name || derivedUsername,
       avatarUrl: user.picture,
+      provider: "google",
     });
 
     return Response.redirect(`${siteUrl}/guestbook`);

--- a/src/app/api/guestbook/route.ts
+++ b/src/app/api/guestbook/route.ts
@@ -7,6 +7,7 @@ async function ensureTable() {
     CREATE TABLE IF NOT EXISTS guestbook (
       id SERIAL PRIMARY KEY,
       github_id TEXT NOT NULL,
+      provider TEXT NOT NULL DEFAULT 'github',
       username TEXT NOT NULL,
       name TEXT NOT NULL,
       avatar_url TEXT NOT NULL,
@@ -27,6 +28,9 @@ async function ensureTable() {
 
   await sql`
     ALTER TABLE guestbook ADD COLUMN IF NOT EXISTS signature_data TEXT;
+  `;
+  await sql`
+    ALTER TABLE guestbook ADD COLUMN IF NOT EXISTS provider TEXT NOT NULL DEFAULT 'github';
   `;
   await sql`
     ALTER TABLE guestbook ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ;
@@ -53,7 +57,7 @@ async function ensureTable() {
 export async function GET() {
   await ensureTable();
   const rows = await sql`
-    SELECT id, github_id, username, name, avatar_url, message, signature_data, created_at, updated_at
+    SELECT id, github_id, username, name, avatar_url, message, signature_data, provider, created_at, updated_at
     FROM guestbook
     ORDER BY created_at DESC
     LIMIT 100
@@ -79,15 +83,15 @@ export async function POST(req: NextRequest) {
   await ensureTable();
 
   const rows = await sql`
-    INSERT INTO guestbook (github_id, username, name, avatar_url, message, signature_data)
-    VALUES (${session.githubId}, ${session.username}, ${displayName}, ${session.avatarUrl}, ${message}, ${signatureData})
+    INSERT INTO guestbook (github_id, username, name, avatar_url, message, signature_data, provider)
+    VALUES (${session.userId}, ${session.username}, ${displayName}, ${session.avatarUrl}, ${message}, ${signatureData}, ${session.provider})
     ON CONFLICT (github_id) DO UPDATE SET
       name = EXCLUDED.name,
       message = EXCLUDED.message,
       signature_data = EXCLUDED.signature_data,
       updated_at = NOW()
     -- created_at is intentionally NOT updated
-    RETURNING id, github_id, username, name, avatar_url, message, signature_data, created_at, updated_at
+    RETURNING id, github_id, username, name, avatar_url, message, signature_data, provider, created_at, updated_at
   `;
 
   return Response.json(rows[0], { status: 201 });

--- a/src/app/api/guestbook/route.ts
+++ b/src/app/api/guestbook/route.ts
@@ -51,6 +51,21 @@ async function ensureTable() {
         ALTER TABLE guestbook DROP CONSTRAINT guestbook_github_id_key;
       END IF;
 
+      DELETE FROM guestbook g
+      USING (
+        SELECT id
+        FROM (
+          SELECT id,
+                 ROW_NUMBER() OVER (
+                   PARTITION BY provider, github_id
+                   ORDER BY updated_at DESC NULLS LAST, created_at DESC NULLS LAST, id DESC
+                 ) AS row_num
+          FROM guestbook
+        ) ranked
+        WHERE ranked.row_num > 1
+      ) duplicates
+      WHERE g.id = duplicates.id;
+
       IF NOT EXISTS (
         SELECT 1 FROM pg_constraint WHERE conname = 'guestbook_provider_github_id_key'
       ) THEN

--- a/src/app/api/guestbook/route.ts
+++ b/src/app/api/guestbook/route.ts
@@ -51,6 +51,7 @@ async function ensureTable() {
         ALTER TABLE guestbook DROP CONSTRAINT guestbook_github_id_key;
       END IF;
 
+      -- Keep newest row per (provider, github_id) so composite uniqueness can be enforced safely.
       DELETE FROM guestbook g
       USING (
         SELECT id

--- a/src/app/api/guestbook/route.ts
+++ b/src/app/api/guestbook/route.ts
@@ -45,10 +45,16 @@ async function ensureTable() {
   // Ensure unique constraint exists for UPSERT
   await sql`
     DO $$ BEGIN
-      IF NOT EXISTS (
+      IF EXISTS (
         SELECT 1 FROM pg_constraint WHERE conname = 'guestbook_github_id_key'
       ) THEN
-        ALTER TABLE guestbook ADD CONSTRAINT guestbook_github_id_key UNIQUE (github_id);
+        ALTER TABLE guestbook DROP CONSTRAINT guestbook_github_id_key;
+      END IF;
+
+      IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint WHERE conname = 'guestbook_provider_github_id_key'
+      ) THEN
+        ALTER TABLE guestbook ADD CONSTRAINT guestbook_provider_github_id_key UNIQUE (provider, github_id);
       END IF;
     END $$;
   `;
@@ -85,7 +91,7 @@ export async function POST(req: NextRequest) {
   const rows = await sql`
     INSERT INTO guestbook (github_id, username, name, avatar_url, message, signature_data, provider)
     VALUES (${session.userId}, ${session.username}, ${displayName}, ${session.avatarUrl}, ${message}, ${signatureData}, ${session.provider})
-    ON CONFLICT (github_id) DO UPDATE SET
+    ON CONFLICT (provider, github_id) DO UPDATE SET
       name = EXCLUDED.name,
       message = EXCLUDED.message,
       signature_data = EXCLUDED.signature_data,

--- a/src/app/api/guestbook/route.ts
+++ b/src/app/api/guestbook/route.ts
@@ -51,25 +51,25 @@ async function ensureTable() {
         ALTER TABLE guestbook DROP CONSTRAINT guestbook_github_id_key;
       END IF;
 
-      -- Keep newest row per (provider, github_id) so composite uniqueness can be enforced safely.
-      DELETE FROM guestbook g
-      USING (
-        SELECT id
-        FROM (
-          SELECT id,
-                 ROW_NUMBER() OVER (
-                   PARTITION BY provider, github_id
-                   ORDER BY updated_at DESC NULLS LAST, created_at DESC NULLS LAST, id DESC
-                 ) AS row_num
-          FROM guestbook
-        ) ranked
-        WHERE ranked.row_num > 1
-      ) duplicates
-      WHERE g.id = duplicates.id;
-
       IF NOT EXISTS (
         SELECT 1 FROM pg_constraint WHERE conname = 'guestbook_provider_github_id_key'
       ) THEN
+        -- One-time cleanup: keep newest row per (provider, github_id) before adding composite uniqueness.
+        DELETE FROM guestbook g
+        USING (
+          SELECT id
+          FROM (
+            SELECT id,
+                   ROW_NUMBER() OVER (
+                     PARTITION BY provider, github_id
+                     ORDER BY updated_at DESC NULLS LAST, created_at DESC NULLS LAST, id DESC
+                   ) AS row_num
+            FROM guestbook
+          ) ranked
+          WHERE ranked.row_num > 1
+        ) duplicates
+        WHERE g.id = duplicates.id;
+
         ALTER TABLE guestbook ADD CONSTRAINT guestbook_provider_github_id_key UNIQUE (provider, github_id);
       END IF;
     END $$;

--- a/src/app/api/posts/[slug]/comments/[commentId]/reactions/route.ts
+++ b/src/app/api/posts/[slug]/comments/[commentId]/reactions/route.ts
@@ -47,7 +47,7 @@ export async function POST(req: NextRequest, { params }: RouteParams) {
 
   if (session) {
     const [existing] = await sql`
-      SELECT id, reaction_type FROM comment_reactions WHERE comment_id = ${id} AND github_id = ${session.githubId}
+      SELECT id, reaction_type FROM comment_reactions WHERE comment_id = ${id} AND github_id = ${session.userId}
     `;
     if (existing) {
       if (existing.reaction_type === reaction) {
@@ -61,7 +61,7 @@ export async function POST(req: NextRequest, { params }: RouteParams) {
       // No reaction -> insert
       await sql`
         INSERT INTO comment_reactions (comment_id, github_id, username, reaction_type)
-        VALUES (${id}, ${session.githubId}, ${session.username}, ${reaction})
+        VALUES (${id}, ${session.userId}, ${session.username}, ${reaction})
       `;
     }
   } else {

--- a/src/app/api/posts/[slug]/comments/[commentId]/replies/[replyId]/reactions/route.ts
+++ b/src/app/api/posts/[slug]/comments/[commentId]/replies/[replyId]/reactions/route.ts
@@ -47,7 +47,7 @@ export async function POST(req: NextRequest, { params }: RouteParams) {
 
   if (session) {
     const [existing] = await sql`
-      SELECT id, reaction_type FROM reply_reactions WHERE reply_id = ${id} AND github_id = ${session.githubId}
+      SELECT id, reaction_type FROM reply_reactions WHERE reply_id = ${id} AND github_id = ${session.userId}
     `;
     if (existing) {
       if (existing.reaction_type === reaction) {
@@ -58,7 +58,7 @@ export async function POST(req: NextRequest, { params }: RouteParams) {
     } else {
       await sql`
         INSERT INTO reply_reactions (reply_id, github_id, username, reaction_type)
-        VALUES (${id}, ${session.githubId}, ${session.username}, ${reaction})
+        VALUES (${id}, ${session.userId}, ${session.username}, ${reaction})
       `;
     }
   } else {

--- a/src/app/api/posts/[slug]/comments/[commentId]/replies/route.ts
+++ b/src/app/api/posts/[slug]/comments/[commentId]/replies/route.ts
@@ -33,9 +33,9 @@ export async function POST(req: NextRequest, { params }: RouteParams) {
   }
 
   const [reply] = await sql`
-    INSERT INTO post_replies (comment_id, github_id, username, name, avatar_url, body)
-    VALUES (${id}, ${session.githubId}, ${session.username}, ${session.name}, ${session.avatarUrl}, ${text})
-    RETURNING id, github_id, username, name, avatar_url, body, created_at
+    INSERT INTO post_replies (comment_id, github_id, username, name, avatar_url, body, provider)
+    VALUES (${id}, ${session.userId}, ${session.username}, ${session.name}, ${session.avatarUrl}, ${text}, ${session.provider})
+    RETURNING id, github_id, username, name, avatar_url, body, provider, created_at
   `;
 
   return Response.json(reply, { status: 201 });

--- a/src/app/api/posts/[slug]/comments/[commentId]/route.ts
+++ b/src/app/api/posts/[slug]/comments/[commentId]/route.ts
@@ -33,7 +33,7 @@ export async function DELETE(_req: NextRequest, { params }: RouteParams) {
 
   const adminUsername = siteConfig.admin.username;
   const isAdmin = session.username === adminUsername;
-  const isOwner = comment.github_id === session.githubId;
+  const isOwner = comment.github_id === session.userId;
 
   if (!isOwner && !isAdmin) {
     return Response.json({ error: "Forbidden" }, { status: 403 });

--- a/src/app/api/posts/[slug]/comments/route.ts
+++ b/src/app/api/posts/[slug]/comments/route.ts
@@ -29,13 +29,13 @@ export async function GET(req: NextRequest, { params }: RouteParams) {
   const anonId = session ? null : hashIp(getClientIp(req));
   
   // Identifiers to match likes
-  const viewerGithubId = session?.githubId ?? null;
+  const viewerGithubId = session?.userId ?? null;
   const viewerAnonId = anonId ?? null;
 
   // Query returns reaction map counts + specific user reaction string
   const comments = await sql`
     SELECT
-      c.id, c.github_id, c.username, c.name, c.avatar_url, c.body, c.created_at,
+      c.id, c.github_id, c.username, c.name, c.avatar_url, c.body, c.provider, c.created_at,
       (
         SELECT COALESCE(json_object_agg(reaction_type, count), '{}') FROM (
           SELECT reaction_type, COUNT(*)::integer AS count
@@ -60,6 +60,7 @@ export async function GET(req: NextRequest, { params }: RouteParams) {
             'name', r.name,
             'avatar_url', r.avatar_url,
             'body', r.body,
+            'provider', r.provider,
             'created_at', r.created_at,
             'reactions_map', (
               SELECT COALESCE(json_object_agg(reaction_type, count), '{}') FROM (
@@ -108,9 +109,9 @@ export async function POST(req: NextRequest, { params }: RouteParams) {
   await ensureInteractionsTables();
 
   const [comment] = await sql`
-    INSERT INTO post_comments (post_slug, github_id, username, name, avatar_url, body)
-    VALUES (${slug}, ${session.githubId}, ${session.username}, ${session.name}, ${session.avatarUrl}, ${text})
-    RETURNING id, github_id, username, name, avatar_url, body, created_at
+    INSERT INTO post_comments (post_slug, github_id, username, name, avatar_url, body, provider)
+    VALUES (${slug}, ${session.userId}, ${session.username}, ${session.name}, ${session.avatarUrl}, ${text}, ${session.provider})
+    RETURNING id, github_id, username, name, avatar_url, body, provider, created_at
   `;
 
   return Response.json({

--- a/src/app/api/posts/[slug]/reactions/route.ts
+++ b/src/app/api/posts/[slug]/reactions/route.ts
@@ -60,7 +60,7 @@ export async function GET(req: NextRequest, { params }: RouteParams) {
   }
   const anonId = session ? null : hashIp(getClientIp(req));
 
-  return Response.json(await getTotals(slug, session?.githubId, anonId));
+  return Response.json(await getTotals(slug, session?.userId, anonId));
 }
 
 export async function POST(req: NextRequest, { params }: RouteParams) {
@@ -79,7 +79,7 @@ export async function POST(req: NextRequest, { params }: RouteParams) {
   if (session) {
     await sql`
       INSERT INTO post_reactions (post_slug, github_id, username, reaction_count)
-      VALUES (${slug}, ${session.githubId}, ${session.username}, ${delta})
+      VALUES (${slug}, ${session.userId}, ${session.username}, ${delta})
       ON CONFLICT (post_slug, github_id) WHERE github_id IS NOT NULL
       DO UPDATE SET reaction_count = LEAST(post_reactions.reaction_count + EXCLUDED.reaction_count, ${MAX_LIKES})
     `;
@@ -92,5 +92,5 @@ export async function POST(req: NextRequest, { params }: RouteParams) {
     `;
   }
 
-  return Response.json(await getTotals(slug, session?.githubId, anonId));
+  return Response.json(await getTotals(slug, session?.userId, anonId));
 }

--- a/src/app/guestbook/GuestbookClient.tsx
+++ b/src/app/guestbook/GuestbookClient.tsx
@@ -16,7 +16,7 @@ import {
 } from "@/hooks/useGuestbook";
 
 interface Session {
-  githubId: string;
+  userId: string;
   username: string;
   name: string;
   avatarUrl: string;
@@ -45,7 +45,7 @@ export function GuestbookClient({
   const { mutateAsync: signGuestbook, isPending: submitting } = useSignGuestbook();
 
   const existingEntry = session
-    ? entries.find((entry) => entry.github_id === session.githubId) ?? null
+    ? entries.find((entry) => entry.github_id === session.userId) ?? null
     : null;
   const hasSigned = existingEntry !== null;
 
@@ -445,14 +445,18 @@ export function GuestbookClient({
                       className="rounded-full object-cover shrink-0"
                     />
                     <div className="flex flex-col min-w-0">
-                      <a
-                        href={`https://github.com/${entry.username}`}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="text-xs font-semibold text-foreground hover:opacity-70 transition-opacity truncate"
-                      >
-                        {entry.name}
-                      </a>
+                      {entry.provider === "github" ? (
+                        <a
+                          href={`https://github.com/${entry.username}`}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-xs font-semibold text-foreground hover:opacity-70 transition-opacity truncate"
+                        >
+                          {entry.name}
+                        </a>
+                      ) : (
+                        <span className="text-xs font-semibold text-foreground truncate">{entry.name}</span>
+                      )}
                       <span
                         className="text-[10px] text-zinc-400 dark:text-zinc-500"
                         title={new Date(entry.created_at).toLocaleString()}

--- a/src/app/guestbook/page.tsx
+++ b/src/app/guestbook/page.tsx
@@ -16,6 +16,7 @@ interface Entry {
   avatar_url: string;
   message: string;
   signature_data: string | null;
+  provider: "github" | "google";
   created_at: string;
   updated_at: string | null;
 }

--- a/src/components/PostInteractions.tsx
+++ b/src/components/PostInteractions.tsx
@@ -19,7 +19,7 @@ import {
 } from "@/hooks/usePostInteractions";
 
 interface Session {
-  githubId: string;
+  userId: string;
   username: string;
   name: string;
   avatarUrl: string;
@@ -156,7 +156,7 @@ function CommentItem({
   const { mutate: toggleCommentReaction } = useToggleCommentReaction(slug);
   const { mutate: toggleReplyReaction } = useToggleReplyReaction(slug);
 
-  const isOwner = session?.githubId === comment.github_id;
+  const isOwner = session?.userId === comment.github_id;
   const isAdmin = session?.username === adminUsername;
   const canDelete = isOwner || isAdmin;
 
@@ -227,14 +227,18 @@ function CommentItem({
         <Avatar src={comment.avatar_url} alt={comment.name} size={28} />
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2 flex-wrap">
-            <a
-              href={`https://github.com/${comment.username}`}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-xs font-semibold text-foreground hover:opacity-70 transition-opacity"
-            >
-              {comment.name}
-            </a>
+            {comment.provider === "github" ? (
+              <a
+                href={`https://github.com/${comment.username}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-xs font-semibold text-foreground hover:opacity-70 transition-opacity"
+              >
+                {comment.name}
+              </a>
+            ) : (
+              <span className="text-xs font-semibold text-foreground">{comment.name}</span>
+            )}
             <span className="text-[10px] text-zinc-400 dark:text-zinc-500">
               {formatDistanceToNow(new Date(comment.created_at), { addSuffix: true })}
             </span>
@@ -313,14 +317,18 @@ function CommentItem({
               <Avatar src={reply.avatar_url} alt={reply.name} size={20} />
               <div className="flex-1 min-w-0">
                 <div className="flex items-center gap-2 flex-wrap">
-                  <a
-                    href={`https://github.com/${reply.username}`}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="text-xs font-semibold text-foreground hover:opacity-70 transition-opacity"
-                  >
-                    {reply.name}
-                  </a>
+                  {reply.provider === "github" ? (
+                    <a
+                      href={`https://github.com/${reply.username}`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-xs font-semibold text-foreground hover:opacity-70 transition-opacity"
+                    >
+                      {reply.name}
+                    </a>
+                  ) : (
+                    <span className="text-xs font-semibold text-foreground">{reply.name}</span>
+                  )}
                   <span className="text-[10px] text-zinc-400 dark:text-zinc-500">
                     {formatDistanceToNow(new Date(reply.created_at), { addSuffix: true })}
                   </span>

--- a/src/hooks/useGuestbook.ts
+++ b/src/hooks/useGuestbook.ts
@@ -9,6 +9,7 @@ export interface Entry {
   avatar_url: string;
   message: string;
   signature_data: string | null;
+  provider: "github" | "google";
   created_at: string;
   updated_at: string | null;
 }

--- a/src/hooks/usePostInteractions.ts
+++ b/src/hooks/usePostInteractions.ts
@@ -8,6 +8,7 @@ export interface Reply {
   name: string;
   avatar_url: string;
   body: string;
+  provider: "github" | "google";
   created_at: string;
   reactions_map: Record<string, number>;
   user_reaction: string | null;
@@ -20,6 +21,7 @@ export interface Comment {
   name: string;
   avatar_url: string;
   body: string;
+  provider: "github" | "google";
   created_at: string;
   replies: Reply[];
   reactions_map: Record<string, number>;

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -4,7 +4,11 @@ export const siteConfig = {
     url: process.env.DATABASE_URL || "",
   },
   auth: {
-    sessionSecret: process.env.SESSION_SECRET || "development_secret_key_please_change",
+    sessionSecret:
+      process.env.SESSION_SECRET ||
+      (process.env.NODE_ENV === "production"
+        ? (() => { throw new Error("SESSION_SECRET env var is not set") })()
+        : "dev_secret_change_me"),
     github: {
       clientId: process.env.GITHUB_CLIENT_ID || "",
       clientSecret: process.env.GITHUB_CLIENT_SECRET || "",

--- a/src/lib/interactions-db.ts
+++ b/src/lib/interactions-db.ts
@@ -82,11 +82,18 @@ export async function resolveUnifiedUser({ email, githubId, googleId }: UserIden
   }
 
   // 4. Create new profile with provider-namespaced canonical ID to prevent cross-provider collisions.
+  const providerIdPattern = /^[A-Za-z0-9._-]+$/;
   let canonicalId: string;
   if (githubId) {
-    canonicalId = `github:${Buffer.from(githubId).toString("base64url")}`;
+    if (!providerIdPattern.test(githubId)) {
+      throw new Error("resolveUnifiedUser: invalid githubId");
+    }
+    canonicalId = `github:${githubId}`;
   } else if (googleId) {
-    canonicalId = `google:${Buffer.from(googleId).toString("base64url")}`;
+    if (!providerIdPattern.test(googleId)) {
+      throw new Error("resolveUnifiedUser: invalid googleId");
+    }
+    canonicalId = `google:${googleId}`;
   } else {
     throw new Error("resolveUnifiedUser: at least one provider ID is required");
   }

--- a/src/lib/interactions-db.ts
+++ b/src/lib/interactions-db.ts
@@ -86,12 +86,12 @@ export async function resolveUnifiedUser({ email, githubId, googleId }: UserIden
   let canonicalId: string;
   if (githubId) {
     if (!providerIdPattern.test(githubId)) {
-      throw new Error("resolveUnifiedUser: invalid githubId");
+      throw new Error("resolveUnifiedUser: githubId must contain only alphanumeric characters");
     }
     canonicalId = `github:${githubId}`;
   } else if (googleId) {
     if (!providerIdPattern.test(googleId)) {
-      throw new Error("resolveUnifiedUser: invalid googleId");
+      throw new Error("resolveUnifiedUser: googleId must contain only alphanumeric characters");
     }
     canonicalId = `google:${googleId}`;
   } else {

--- a/src/lib/interactions-db.ts
+++ b/src/lib/interactions-db.ts
@@ -82,7 +82,7 @@ export async function resolveUnifiedUser({ email, githubId, googleId }: UserIden
   }
 
   // 4. Create new profile with provider-namespaced canonical ID to prevent cross-provider collisions.
-  const providerIdPattern = /^[A-Za-z0-9._-]+$/;
+  const providerIdPattern = /^[A-Za-z0-9]+$/;
   let canonicalId: string;
   if (githubId) {
     if (!providerIdPattern.test(githubId)) {

--- a/src/lib/interactions-db.ts
+++ b/src/lib/interactions-db.ts
@@ -82,8 +82,8 @@ export async function resolveUnifiedUser({ email, githubId, googleId }: UserIden
   }
 
   // 4. Create new profile. We use the incoming platform ID as the canonical ID to support legacy comments.
-  const universalId = githubId || googleId || "";
-  if (!universalId) return "";
+  const universalId = githubId || googleId;
+  if (!universalId) throw new Error("resolveUnifiedUser: at least one provider ID is required");
 
   await safeRun(() => sql`
     INSERT INTO user_accounts (id, email, github_id, google_id)
@@ -229,6 +229,14 @@ async function _init() {
 
   await safeRun(() => sql`
     ALTER TABLE reply_reactions ADD COLUMN IF NOT EXISTS reaction_type TEXT NOT NULL DEFAULT 'heart'
+  `);
+
+  // MIGRATIONS: Add provider column to comments and replies
+  await safeRun(() => sql`
+    ALTER TABLE post_comments ADD COLUMN IF NOT EXISTS provider TEXT NOT NULL DEFAULT 'github'
+  `);
+  await safeRun(() => sql`
+    ALTER TABLE post_replies ADD COLUMN IF NOT EXISTS provider TEXT NOT NULL DEFAULT 'github'
   `);
 
   // MIGRATIONS: Safely alter all existing github_id columns from INTEGER to TEXT

--- a/src/lib/interactions-db.ts
+++ b/src/lib/interactions-db.ts
@@ -81,13 +81,19 @@ export async function resolveUnifiedUser({ email, githubId, googleId }: UserIden
     return existing.id;
   }
 
-  // 4. Create new profile. We use the incoming platform ID as the canonical ID to support legacy comments.
-  const universalId = githubId || googleId;
-  if (!universalId) throw new Error("resolveUnifiedUser: at least one provider ID is required");
+  // 4. Create new profile with provider-namespaced canonical ID to prevent cross-provider collisions.
+  let canonicalId: string;
+  if (githubId) {
+    canonicalId = `github:${githubId}`;
+  } else if (googleId) {
+    canonicalId = `google:${googleId}`;
+  } else {
+    throw new Error("resolveUnifiedUser: at least one provider ID is required");
+  }
 
   await safeRun(() => sql`
     INSERT INTO user_accounts (id, email, github_id, google_id)
-    VALUES (${universalId}, ${normalizedEmail}, ${githubId || null}, ${googleId || null})
+    VALUES (${canonicalId}, ${normalizedEmail}, ${githubId || null}, ${googleId || null})
     ON CONFLICT DO NOTHING
   `);
 
@@ -105,7 +111,7 @@ export async function resolveUnifiedUser({ email, githubId, googleId }: UserIden
     if (row) return row.id;
   }
 
-  return universalId;
+  return canonicalId;
 }
 
 async function _init() {

--- a/src/lib/interactions-db.ts
+++ b/src/lib/interactions-db.ts
@@ -84,9 +84,9 @@ export async function resolveUnifiedUser({ email, githubId, googleId }: UserIden
   // 4. Create new profile with provider-namespaced canonical ID to prevent cross-provider collisions.
   let canonicalId: string;
   if (githubId) {
-    canonicalId = `github:${githubId}`;
+    canonicalId = `github:${Buffer.from(githubId).toString("base64url")}`;
   } else if (googleId) {
-    canonicalId = `google:${googleId}`;
+    canonicalId = `google:${Buffer.from(googleId).toString("base64url")}`;
   } else {
     throw new Error("resolveUnifiedUser: at least one provider ID is required");
   }

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -5,10 +5,11 @@ const SESSION_COOKIE = "gb_session";
 const MAX_AGE = 60 * 60 * 24 * 7; // 7 days
 
 export interface SessionData {
-  githubId: string;
+  userId: string;
   username: string;
   name: string;
   avatarUrl: string;
+  provider: "github" | "google";
 }
 
 async function sign(payload: string, secret: string): Promise<string> {

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -12,6 +12,33 @@ export interface SessionData {
   provider: "github" | "google";
 }
 
+function normalizeSessionData(data: unknown): SessionData | null {
+  if (!data || typeof data !== "object") return null;
+
+  const session = data as Record<string, unknown>;
+  const legacyGithubId = typeof session.githubId === "string" ? session.githubId : undefined;
+  const userId = typeof session.userId === "string" ? session.userId : legacyGithubId;
+
+  const providerValue =
+    session.provider === "github" || session.provider === "google"
+      ? session.provider
+      : undefined;
+  const provider = providerValue ?? (legacyGithubId ? "github" : undefined);
+
+  if (!userId || !provider) return null;
+  if (typeof session.username !== "string") return null;
+  if (typeof session.name !== "string") return null;
+  if (typeof session.avatarUrl !== "string") return null;
+
+  return {
+    userId,
+    username: session.username,
+    name: session.name,
+    avatarUrl: session.avatarUrl,
+    provider,
+  };
+}
+
 async function sign(payload: string, secret: string): Promise<string> {
   const key = await crypto.subtle.importKey(
     "raw",
@@ -52,7 +79,8 @@ export async function decryptSession(raw: string | undefined): Promise<SessionDa
   const sig = raw.slice(dot + 1);
   if (!(await verify(payload, sig, secret))) return null;
   try {
-    return JSON.parse(Buffer.from(payload, "base64url").toString()) as SessionData;
+    const parsed = JSON.parse(Buffer.from(payload, "base64url").toString()) as unknown;
+    return normalizeSessionData(parsed);
   } catch {
     return null;
   }


### PR DESCRIPTION
This pull request adds support for multiple authentication providers (GitHub and Google) across the guestbook and post interactions features. The main changes include normalizing user identifiers to a provider-agnostic `userId`, tracking the authentication provider in the database, updating API routes and UI components to handle provider-specific logic, and updating TypeScript types accordingly.

**Authentication and Session Handling:**

- Replaced all usage of `githubId` with a generic `userId` in session objects and throughout the codebase to support multiple providers. The session object now also stores the `provider` field to indicate the authentication source. [[1]](diffhunk://#diff-f3781d31e7dc810139646418ccb0bd334a08015f8646f2d215bf5d054612fa0bL78-R82) [[2]](diffhunk://#diff-3fe1143da0c7a4ef0a81a753bc8c604343f7c05b7de64c356d5a7a51bddb16dbL72-R76) [[3]](diffhunk://#diff-1847df7f00d733b80da43ae44f746fff4b390f3f322f74d4f5fa6630c4eb632eL19-R19) [[4]](diffhunk://#diff-385937108b8c41e3a960342a60a076ec09d7bdb344b99b2a7fef2dd20c46cb52L22-R22)

**Database Schema and API Updates:**

- Modified the `guestbook`, `post_comments`, and `post_replies` tables to include a new `provider` column, defaulting to `"github"` for backward compatibility. Updated all relevant SQL queries and insertions to handle the new `provider` field. [[1]](diffhunk://#diff-8c6c3bb92adbf6d090741c5430673423b687cb759e2e962167dc560c382e9664R10) [[2]](diffhunk://#diff-8c6c3bb92adbf6d090741c5430673423b687cb759e2e962167dc560c382e9664R32-R34) [[3]](diffhunk://#diff-8c6c3bb92adbf6d090741c5430673423b687cb759e2e962167dc560c382e9664L56-R60) [[4]](diffhunk://#diff-8c6c3bb92adbf6d090741c5430673423b687cb759e2e962167dc560c382e9664L82-R94) [src/app/api/posts/[slug]/comments/[commentId]/replies/route.tsL36-R38](diffhunk://#diff-fd8931ebafb8921f4605eb8e90976e49a8662376a2d2b001e60f44aa2acbc555L36-R38), [src/app/api/posts/[slug]/comments/route.tsL32-R38](diffhunk://#diff-d471e661710de6dff82f83034240152083d11b7139c9e03bdeab7e4de38bb86fL32-R38), [src/app/api/posts/[slug]/comments/route.tsR63](diffhunk://#diff-d471e661710de6dff82f83034240152083d11b7139c9e03bdeab7e4de38bb86fR63), [src/app/api/posts/[slug]/comments/route.tsL111-R114](diffhunk://#diff-d471e661710de6dff82f83034240152083d11b7139c9e03bdeab7e4de38bb86fL111-R114))

**API Route Logic:**

- Updated all API routes for comments, replies, reactions, and guestbook entries to use `userId` instead of `githubId` for user identification, ensuring consistent multi-provider support. ([src/app/api/posts/[slug]/comments/[commentId]/reactions/route.tsL50-R50](diffhunk://#diff-eb6da238cea1fb34e7a2bff1fd981fcf278b587489602b572b32eec15f0b2509L50-R50), [src/app/api/posts/[slug]/comments/[commentId]/reactions/route.tsL64-R64](diffhunk://#diff-eb6da238cea1fb34e7a2bff1fd981fcf278b587489602b572b32eec15f0b2509L64-R64), [src/app/api/posts/[slug]/comments/[commentId]/replies/[replyId]/reactions/route.tsL50-R50](diffhunk://#diff-5df55db69004add097c4b1ca4a1f81e394652a6f6d0a944e7f91b201cf19d60aL50-R50), [src/app/api/posts/[slug]/comments/[commentId]/replies/[replyId]/reactions/route.tsL61-R61](diffhunk://#diff-5df55db69004add097c4b1ca4a1f81e394652a6f6d0a944e7f91b201cf19d60aL61-R61), [src/app/api/posts/[slug]/comments/[commentId]/route.tsL36-R36](diffhunk://#diff-cc737f4977210dc5000291266c8659979eba95a1dfe6ec4ec518af38b7882d74L36-R36), [src/app/api/posts/[slug]/reactions/route.tsL63-R63](diffhunk://#diff-2d022e6a809e99c8b9d4b274ffd8a23e5c1274f1f2032267284b19e8b3bbd2a4L63-R63), [src/app/api/posts/[slug]/reactions/route.tsL82-R82](diffhunk://#diff-2d022e6a809e99c8b9d4b274ffd8a23e5c1274f1f2032267284b19e8b3bbd2a4L82-R82), [src/app/api/posts/[slug]/reactions/route.tsL95-R95](diffhunk://#diff-2d022e6a809e99c8b9d4b274ffd8a23e5c1274f1f2032267284b19e8b3bbd2a4L95-R95))

**TypeScript Types and Interfaces:**

- Updated TypeScript interfaces (`Entry`, `Comment`, `Reply`, and related types) to include the `provider` field and reflect the new structure for user identification. [[1]](diffhunk://#diff-14bc5f0180c4d84d7d5c5499fad88b50fb8e7b60ba771e887791ace28b4e154cR19) [[2]](diffhunk://#diff-72eeac55693e535f5a8246040c8326d257175712c77d6c751c60650ea220be38R12) [[3]](diffhunk://#diff-59190704d14df19b997c7425b0e38b9ad23220516c6952ee883c7e8917c0c78eR11) [[4]](diffhunk://#diff-59190704d14df19b997c7425b0e38b9ad23220516c6952ee883c7e8917c0c78eR24)

**UI Adjustments:**

- Modified UI components in the guestbook and post interactions to display user names differently based on the authentication provider (linking to GitHub profiles for GitHub users and displaying plain text for Google users). [[1]](diffhunk://#diff-1847df7f00d733b80da43ae44f746fff4b390f3f322f74d4f5fa6630c4eb632eL48-R48) [[2]](diffhunk://#diff-1847df7f00d733b80da43ae44f746fff4b390f3f322f74d4f5fa6630c4eb632eR448) [[3]](diffhunk://#diff-1847df7f00d733b80da43ae44f746fff4b390f3f322f74d4f5fa6630c4eb632eR457-R459) [[4]](diffhunk://#diff-385937108b8c41e3a960342a60a076ec09d7bdb344b99b2a7fef2dd20c46cb52L159-R159) [[5]](diffhunk://#diff-385937108b8c41e3a960342a60a076ec09d7bdb344b99b2a7fef2dd20c46cb52R230) [[6]](diffhunk://#diff-385937108b8c41e3a960342a60a076ec09d7bdb344b99b2a7fef2dd20c46cb52R239-R241) [[7]](diffhunk://#diff-385937108b8c41e3a960342a60a076ec09d7bdb344b99b2a7fef2dd20c46cb52R320) [[8]](diffhunk://#diff-385937108b8c41e3a960342a60a076ec09d7bdb344b99b2a7fef2dd20c46cb52R329-R331)

These changes collectively enable seamless support for both GitHub and Google authentication, improve data consistency, and ensure the UI accurately reflects the user's authentication provider.