### PR TITLE
[feat]: refactor auth routes via proxy and integrate Google One Tap component

### DIFF
--- a/src/app/api/auth/google/one-tap/route.ts
+++ b/src/app/api/auth/google/one-tap/route.ts
@@ -1,0 +1,55 @@
+import { NextRequest } from "next/server";
+import { setSession } from "@/lib/session";
+import { resolveUnifiedUser } from "@/lib/interactions-db";
+import { siteConfig } from "@/lib/config";
+
+interface GoogleTokenInfo {
+  sub: string;
+  email?: string;
+  email_verified?: string;
+  name: string;
+  picture: string;
+  aud: string;
+}
+
+export async function POST(req: NextRequest) {
+  const body = await req.json() as { credential?: string };
+  const { credential } = body;
+
+  if (!credential) {
+    return Response.json({ error: "Missing credential" }, { status: 400 });
+  }
+
+  const tokenRes = await fetch(
+    `https://oauth2.googleapis.com/tokeninfo?id_token=${credential}`
+  );
+
+  if (!tokenRes.ok) {
+    return Response.json({ error: "Invalid credential" }, { status: 401 });
+  }
+
+  const info = await tokenRes.json() as GoogleTokenInfo;
+
+  if (info.aud !== siteConfig.auth.google.clientId) {
+    return Response.json({ error: "Token audience mismatch" }, { status: 401 });
+  }
+
+  const derivedUsername = info.email
+    ? info.email.split("@")[0].replace(/[^a-zA-Z0-9_]/g, "") || "google_user"
+    : info.name.toLowerCase().replace(/\s+/g, "_").replace(/[^a-zA-Z0-9_]/g, "") || "google_user";
+
+  const canonicalId = await resolveUnifiedUser({
+    googleId: info.sub,
+    email: info.email ?? null,
+  });
+
+  await setSession({
+    userId: canonicalId,
+    username: derivedUsername,
+    name: info.name || derivedUsername,
+    avatarUrl: info.picture,
+    provider: "google",
+  });
+
+  return Response.json({ ok: true });
+}

--- a/src/app/guestbook/GuestbookClient.tsx
+++ b/src/app/guestbook/GuestbookClient.tsx
@@ -97,7 +97,7 @@ export function GuestbookClient({
   }
 
   async function handleSignOut() {
-    await axios.post("/api/auth/signout");
+    await axios.post("/auth/signout");
     window.location.reload();
   }
 
@@ -155,14 +155,14 @@ export function GuestbookClient({
                 <div className="flex items-center gap-1.5">
                   <span className="text-xs text-zinc-500 mr-0.5">Sign in:</span>
                   <Link
-                    href="/api/auth/github"
+                    href="/auth/github"
                     title="Sign in with GitHub"
                     className="inline-flex items-center justify-center w-8 h-8 rounded-lg bg-zinc-800 text-zinc-300 hover:bg-zinc-700 hover:text-white transition-colors"
                   >
                     <SiGithub size={14} />
                   </Link>
                   <Link
-                    href="/api/auth/google"
+                    href="/auth/google"
                     title="Sign in with Google"
                     className="inline-flex items-center justify-center w-8 h-8 rounded-lg bg-zinc-800 hover:bg-zinc-700 transition-colors"
                   >
@@ -307,14 +307,14 @@ export function GuestbookClient({
                 </p>
                 <div className="flex items-center gap-2 flex-wrap">
                   <Link
-                    href="/api/auth/github"
+                    href="/auth/github"
                     className="inline-flex items-center gap-2 text-xs font-medium px-3 py-1.5 rounded-lg bg-zinc-100 hover:bg-zinc-200 dark:bg-zinc-800 dark:hover:bg-zinc-700 text-foreground transition-colors"
                   >
                     <SiGithub size={13} />
                     GitHub
                   </Link>
                   <Link
-                    href="/api/auth/google"
+                    href="/auth/google"
                     className="inline-flex items-center gap-2 text-xs font-medium px-3 py-1.5 rounded-lg bg-zinc-100 hover:bg-zinc-200 dark:bg-zinc-800 dark:hover:bg-zinc-700 text-foreground transition-colors"
                   >
                     <FcGoogle size={13} />

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Poppins } from "next/font/google";
 import { Header, Footer, ThemeProvider, QueryProvider } from "@/components";
+import { GoogleOneTap } from "@/components/ui";
 import { Analytics } from "@vercel/analytics/next";
 import "./globals.css";
 import { SpeedInsights } from "@vercel/speed-insights/next";
@@ -136,6 +137,10 @@ export default function RootLayout({
             <Footer />
           </QueryProvider>
         </ThemeProvider>
+        {/* One Tap disabled — uncomment to enable site-wide Google sign-in prompt */}
+        {/* {siteConfig.auth.google.clientId && (
+          <GoogleOneTap clientId={siteConfig.auth.google.clientId} />
+        )} */}
         <Analytics />
         <SpeedInsights />
         <Toaster richColors position="top-right" theme="system" closeButton />

--- a/src/components/PostInteractions.tsx
+++ b/src/components/PostInteractions.tsx
@@ -668,14 +668,14 @@ export function PostInteractions({ slug, session, adminUsername }: PostInteracti
             </p>
             <div className="flex items-center gap-2">
               <Link
-                href="/api/auth/github"
+                href="/auth/github"
                 className="inline-flex items-center gap-2 text-xs font-medium px-3 py-2 rounded-lg border border-zinc-200 dark:border-zinc-800 bg-zinc-50 hover:bg-zinc-100 dark:bg-zinc-900/50 dark:hover:bg-zinc-800 text-foreground transition-colors"
               >
                 <SiGithub size={14} className="text-foreground" />
                 GitHub
               </Link>
               <Link
-                href="/api/auth/google"
+                href="/auth/google"
                 className="inline-flex items-center gap-2 text-xs font-medium px-3 py-2 rounded-lg border border-zinc-200 dark:border-zinc-800 bg-zinc-50 hover:bg-zinc-100 dark:bg-zinc-900/50 dark:hover:bg-zinc-800 text-foreground transition-colors"
               >
                 <FcGoogle size={14} />

--- a/src/components/ui/GoogleOneTap.tsx
+++ b/src/components/ui/GoogleOneTap.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { useEffect } from "react";
+
+declare global {
+  interface Window {
+    google?: {
+      accounts: {
+        id: {
+          initialize: (config: object) => void;
+          prompt: () => void;
+          cancel: () => void;
+        };
+      };
+    };
+  }
+}
+
+export function GoogleOneTap({ clientId }: { clientId: string }) {
+  useEffect(() => {
+    const script = document.createElement("script");
+    script.src = "https://accounts.google.com/gsi/client";
+    script.async = true;
+    script.defer = true;
+    document.body.appendChild(script);
+
+    script.onload = () => {
+      window.google?.accounts.id.initialize({
+        client_id: clientId,
+        callback: async (response: { credential: string }) => {
+          const res = await fetch("/api/auth/google/one-tap", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ credential: response.credential }),
+          });
+          if (res.ok) {
+            window.location.reload();
+          }
+        },
+        auto_select: false,
+        cancel_on_tap_outside: true,
+      });
+      window.google?.accounts.id.prompt();
+    };
+
+    return () => {
+      window.google?.accounts.id.cancel();
+      document.body.removeChild(script);
+    };
+  }, [clientId]);
+
+  return null;
+}

--- a/src/components/ui/index.tsx
+++ b/src/components/ui/index.tsx
@@ -4,5 +4,6 @@ import { SpotifyCard } from "./SpotifyCard";
 import { SignaturePad } from "./SignaturePad";
 import { NowPlaying } from "./NowPlaying";
 import { DjQueueWidget } from "./DjQueueWidget";
+import { GoogleOneTap } from "./GoogleOneTap";
 
-export { MotionHeader, MotionFooter, MotionDiv, Spoiler, SpotifyCard, SignaturePad, NowPlaying, DjQueueWidget };
+export { MotionHeader, MotionFooter, MotionDiv, Spoiler, SpotifyCard, SignaturePad, NowPlaying, DjQueueWidget, GoogleOneTap };

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -4,22 +4,31 @@ import { decryptSession } from "@/lib/session";
 import { siteConfig } from "@/lib/config";
 
 export async function proxy(request: NextRequest) {
-  const cookieValue = request.cookies.get("gb_session")?.value;
-  const session = await decryptSession(cookieValue);
+  const { pathname } = request.nextUrl;
 
-  // Verify admin credentials using edge-compatible cryptographic verifier
-  const isAdmin = session && session.username === siteConfig.admin.username;
-
-  if (!isAdmin) {
+  // Rewrite /auth/:path* → /api/auth/:path* (keeps internal API structure opaque)
+  if (pathname.startsWith("/auth/")) {
     const url = request.nextUrl.clone();
-    url.pathname = "/"; // Bounce unauthorized users to root index
-    return NextResponse.redirect(url);
+    url.pathname = `/api${pathname}`;
+    return NextResponse.rewrite(url);
+  }
+
+  // Guard /music to admin only
+  if (pathname.startsWith("/music")) {
+    const cookieValue = request.cookies.get("gb_session")?.value;
+    const session = await decryptSession(cookieValue);
+    const isAdmin = session && session.username === siteConfig.admin.username;
+
+    if (!isAdmin) {
+      const url = request.nextUrl.clone();
+      url.pathname = "/";
+      return NextResponse.redirect(url);
+    }
   }
 
   return NextResponse.next();
 }
 
-// Strictly bind proxy to target routes to maintain peak speed for other pages
 export const config = {
-  matcher: ["/music/:path*"],
+  matcher: ["/auth/:path*", "/music/:path*"],
 };


### PR DESCRIPTION
This pull request introduces Google One Tap sign-in functionality and refactors authentication route handling to use cleaner, user-facing paths. It adds a new API route for Google One Tap authentication, a reusable `GoogleOneTap` component, and updates the proxy middleware to rewrite `/auth/*` paths to the internal API. All UI links for GitHub and Google sign-in are updated to use the new `/auth/*` routes.

**Authentication improvements:**

* Added a new API route at `src/app/api/auth/google/one-tap/route.ts` to handle Google One Tap sign-in, verifying tokens and creating user sessions.
* Introduced the `GoogleOneTap` React component (`src/components/ui/GoogleOneTap.tsx`) for site-wide Google One Tap sign-in prompts, and exported it via the UI index. [[1]](diffhunk://#diff-eb678f3d2f5c17ac32edea8086be4cf924257e388a4659ec4afea81398764327R1-R53) [[2]](diffhunk://#diff-5aa32f476c077195be27752e5a6b53b6f29112b36dea1607d4ed886486bd4e3bR7-R9)
* Updated all sign-in and sign-out links/buttons in the UI to use `/auth/github` and `/auth/google` instead of `/api/auth/github` and `/api/auth/google`. [[1]](diffhunk://#diff-1847df7f00d733b80da43ae44f746fff4b390f3f322f74d4f5fa6630c4eb632eL100-R100) [[2]](diffhunk://#diff-1847df7f00d733b80da43ae44f746fff4b390f3f322f74d4f5fa6630c4eb632eL158-R165) [[3]](diffhunk://#diff-1847df7f00d733b80da43ae44f746fff4b390f3f322f74d4f5fa6630c4eb632eL310-R317) [[4]](diffhunk://#diff-385937108b8c41e3a960342a60a076ec09d7bdb344b99b2a7fef2dd20c46cb52L671-R678)

**Routing and proxy enhancements:**

* Updated the proxy middleware (`src/proxy.ts`) to rewrite all `/auth/*` requests to `/api/auth/*`, keeping internal API structure hidden and simplifying route handling. The proxy matcher is expanded to include `/auth/:path*`.

**Layout integration:**

* Prepared the root layout (`src/app/layout.tsx`) for optional, site-wide Google One Tap support by conditionally rendering the `GoogleOneTap` component (currently commented out for easy enablement). [[1]](diffhunk://#diff-29d0a55f5ca1a9951042587f8b891bb4cd8b204f5bc855dc2468ed44cde2f5b3R4) [[2]](diffhunk://#diff-29d0a55f5ca1a9951042587f8b891bb4cd8b204f5bc855dc2468ed44cde2f5b3R140-R143)